### PR TITLE
Correct way of searching traits in SchemaFactory

### DIFF
--- a/src/main/scala/fi/oph/scalaschema/SchemaFactory.scala
+++ b/src/main/scala/fi/oph/scalaschema/SchemaFactory.scala
@@ -236,12 +236,11 @@ case class SchemaFactory() {
   }
 
   private def findTraits(tpe: ru.Type) = {
-    tpe.baseClasses
-      .map(_.fullName)
-      .filter(!List("scala.Any").contains(_))
-      .map(typeByName)
-      .filter {_.typeSymbol.asClass.isTrait}
-      .filterNot {_ == tpe}
+    tpe
+      .baseClasses
+      .filter(x => x.fullName != "scala.Any")
+      .map(_.asType.info)
+      .filter(x => x.typeSymbol.asClass.isTrait && x != tpe)
   }
 
   private def applyMetadataFromClassAndTraits[T <: ObjectWithMetadata[T]](tpe: ru.Type, schema: T): T =

--- a/src/test/scala/fi/oph/scalaschema/JsonSchemaTest.scala
+++ b/src/test/scala/fi/oph/scalaschema/JsonSchemaTest.scala
@@ -83,6 +83,9 @@ class JsonSchemaTest extends FreeSpec with Matchers {
       "works for fields" in {
         jsonSchemaOf(classOf[TraitsInFields]) should equal("""{"type":"object","properties":{"field":{"$ref":"#/definitions/traits"}},"id":"#traitsinfields","additionalProperties":false,"title":"Traits in fields","required":["field"],"definitions":{"impla":{"type":"object","properties":{},"id":"#impla","additionalProperties":false,"title":"Impl a"},"implb":{"type":"object","properties":{},"id":"#implb","additionalProperties":false,"title":"Impl b"},"traits":{"anyOf":[{"$ref":"#/definitions/impla"},{"$ref":"#/definitions/implb"}]}}}""")
       }
+      "generate schema for subtypes defined in an object" in {
+        jsonSchemaOf(classOf[BaseTrait]) should equal("""{"anyOf":[{"$ref":"#/definitions/sub1"},{"$ref":"#/definitions/sub2"}],"definitions":{"sub1":{"type":"object","properties":{},"id":"#sub1","additionalProperties":false,"title":"Sub1"},"sub2":{"type":"object","properties":{},"id":"#sub2","additionalProperties":false,"title":"Sub2"}}}""")
+      }
     }
     "JValues" - {
       "JValue" in {

--- a/src/test/scala/fi/oph/scalaschema/TestData.scala
+++ b/src/test/scala/fi/oph/scalaschema/TestData.scala
@@ -132,3 +132,9 @@ case class ReadableFromTwoStrings(value: String, value2: String)
 
 trait MaybeReadableFromString
 case class OtherCase(number: Int) extends MaybeReadableFromString
+
+trait BaseTrait
+object BaseTrait {
+  case object Sub1 extends BaseTrait
+  case object Sub2 extends BaseTrait
+}


### PR DESCRIPTION
Hi, I found that a schema can't be created from the following code -
```
trait BaseTrait
object BaseTrait {
  case object Sub1 extends BaseTrait
  case object Sub2 extends BaseTrait
}

object Test extends App {
  SchemaFactory.default.createSchema(classOf[BaseTrait])
}
```

because of -
```
Exception in thread "main" java.lang.ClassNotFoundException: fi.oph.scalaschema.BaseTrait.Sub1
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at fi.oph.scalaschema.SchemaFactory.fi$oph$scalaschema$SchemaFactory$$typeByName(SchemaFactory.scala:56)
	at fi.oph.scalaschema.SchemaFactory$$anonfun$findTraits$3.apply(SchemaFactory.scala:182)
	at fi.oph.scalaschema.SchemaFactory$$anonfun$findTraits$3.apply(SchemaFactory.scala:182)
```

This PR solves the problem.
What do you think about the solution?