### PR TITLE
Add support to ignore non-validating list items in extraction

### DIFF
--- a/src/main/scala/fi/oph/scalaschema/ExtractionContext.scala
+++ b/src/main/scala/fi/oph/scalaschema/ExtractionContext.scala
@@ -15,7 +15,8 @@ case class ExtractionContext(schemaFactory: SchemaFactory,
                              validate: Boolean = true,
                              ignoreUnexpectedProperties: Boolean = false,
                              allowEmptyStrings: Boolean = true,
-                             criteriaCache: collection.mutable.Map[String, DiscriminatorCriterion] = collection.mutable.Map.empty) {
+                             criteriaCache: collection.mutable.Map[String, DiscriminatorCriterion] = collection.mutable.Map.empty,
+                             ignoreNonValidatingListItems: Boolean = false) {
   def hasSerializerFor(schema: SchemaWithClassName) = customSerializerFor(schema).isDefined
   def customSerializerFor(schema: SchemaWithClassName) = customDeserializers.find(_.isApplicable(schema))
   def ifValidating(errors: => List[ValidationError]) = if (validate) { errors } else { Nil }

--- a/src/main/scala/fi/oph/scalaschema/extraction/ListExtractor.scala
+++ b/src/main/scala/fi/oph/scalaschema/extraction/ListExtractor.scala
@@ -11,7 +11,7 @@ object ListExtractor {
       val valueResults: List[Either[List[ValidationError], Any]] = values.zipWithIndex.map {
         case (itemJson, index) =>
           SchemaValidatingExtractor.extract(cursor.subCursor(itemJson, index.toString), ls.itemSchema, metadata)
-      }
+      }.filter(_.isRight || !context.ignoreNonValidatingListItems)
 
       val metadataValidationErrors: List[ValidationError] = context.ifValidating((ls.metadata ++ metadata).collect {
         case MinItems(minItems) if values.length < minItems => ValidationError(cursor.path, cursor.json, LessThanMinimumNumberOfItems(minItems))

--- a/src/test/scala/fi/oph/scalaschema/ValidationAndExtractionTest.scala
+++ b/src/test/scala/fi/oph/scalaschema/ValidationAndExtractionTest.scala
@@ -42,6 +42,17 @@ class ValidationAndExtractionTest extends AnyFreeSpec with Matchers {
           verifyValidation[TestClass](inputWithExtraField, Right(TestClass("john", List(1))), ExtractionContext(SchemaFactory.default, ignoreUnexpectedProperties = true))
         }
       }
+      "Unexpected non-validating list items" - {
+        val inputWithExtraNonValidatingListItem = JObject(("name" -> JString("john")), ("stuff" -> JArray(List(JInt(1), JBool(true)))))
+        "Cause errors in default/strict mode" in {
+          verifyValidation[TestClass](inputWithExtraNonValidatingListItem, Left(List(
+            ValidationError("stuff.1",JBool(true),UnexpectedType("number"))
+          )))
+        }
+        "Are ignored in loose mode" in {
+          verifyValidation[TestClass](inputWithExtraNonValidatingListItem, Right(TestClass("john", List(1))), ExtractionContext(SchemaFactory.default, ignoreNonValidatingListItems = true))
+        }
+      }
       "Field type validation" in {
         verifyValidation[TestClass](JObject(("name" -> JObject()), ("stuff", JArray(List(JString("a"), JString("b"))))), Left(List(
           ValidationError("name",JObject(),UnexpectedType("string")),


### PR DESCRIPTION
This is required in cases similar to existing ignoreUnexpectedProperties when only subset of the JSON data is required.