### PR TITLE
NotWhen -annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,28 @@ The factory will *cache the created schemas* so that
 subsequent requests for a certain schema will be super fast. Therefore you should store your schema factory in a variable, 
 but you don't need to store the individual schemas.
 
+### Examples of matching multiple case classes
+
+Creating multiple case classes with different combinations of annotations may lead to situations, where the match is not what is expected. These examples are especially related to the use of `@OnlyWhen` and `@NotWhen` -annotations.
+
+The following examples assume, that the case classes extend the same trait.
+
+#### 1. Matches a case class with annotations, and one or more case classes without annotations
+
+If a case class with annotations is matched, and there exists one or more case classes without annotations (that would also meet the matching criteria), the case class with annotations is selected.
+
+#### 2. Does not match a case class with annotations, but matches a case class with no annotations
+
+If there are multiple case classes with annotations defined, but none of them match, the case class with no annotations is selected as the match.
+
+#### 3. Matches every case class with annotations
+
+If there are multiple case classes with annotations defined, and more than one of them match, the deserialising throws `TooManyMatchingCasesException`
+
+#### 4. Matches multiple case classes without annotations
+
+If there are multiple case classes with no annotations, the deserialising throws `TooManyCatchingCasesException`.
+
 ### How to use as dependency
 
 The `scala-schema` library is currently maintained in two branches for scala versions 2.11 and 2.12.
@@ -205,7 +227,7 @@ Add Jitpack.io resolver:
 Then add scala-schema as dependency (use appropriate scala version suffix as below)
 
     libraryDependencies += "com.github.Opetushallitus" % "scala-schema" % "2.23.0_2.12"
-g 
+
 ### Developing scala-schema
 
 Project is built and tested with Maven. So `mvn install` will do the job.

--- a/src/main/scala/fi/oph/scalaschema/ValueConversion.scala
+++ b/src/main/scala/fi/oph/scalaschema/ValueConversion.scala
@@ -1,0 +1,21 @@
+package fi.oph.scalaschema
+
+import org.json4s.{JArray, JValue}
+import org.json4s.JsonAST.{JNull, JSet, JString}
+
+object ValueConversion {
+  def anyToJValue(x: Any): JValue = x match {
+    // If support for a new type of value is needed, it can be added here
+    case None => JNull
+    case Some(x) => anyToJValue(x)
+    case s: String => JString(s)
+    case n: Number => Serializer.serializeNumber(n)
+    case b: Boolean => Serializer.serializeBoolean(b)
+    case _ => throw new IllegalArgumentException("Type not supported here: " + x.getClass)
+  }
+  def anyToJValueWithLists(x: Any): JValue = x match {
+    // If support for a new type of value is needed, it can be added here
+    case a: List[Any] => JArray(a.map(anyToJValueWithLists(_)))
+    case b: Any => anyToJValue(b)
+  }
+}

--- a/src/main/scala/fi/oph/scalaschema/annotation/NotWhen.scala
+++ b/src/main/scala/fi/oph/scalaschema/annotation/NotWhen.scala
@@ -1,0 +1,41 @@
+package fi.oph.scalaschema.annotation
+
+import fi.oph.scalaschema.extraction.JsonCompare
+import fi.oph.scalaschema.{Metadata, ValueConversion}
+import org.json4s.{JArray, JNothing, JNull, JValue, JsonAST}
+
+/**
+ *  Matches, if the path's value is not in the disallowed values list.
+ *  ===Example usage===
+ *  {{{
+ *  case class Car(
+ *    hasTowbar: Boolean
+ *    @NotWhen("hasTowbar", false)
+ *    trailer: Option[Trailer]
+ *  )
+ *  case class Trailer(model: String)
+ *  }}}
+ * @param path [[java.lang.String]] Object path
+ * @param disallowedValues Disallowed values. Can be a [[scala.AnyValCompanion]], [[scala.None]] or a [[scala.collection.immutable.List]] of [[scala.AnyValCompanion]].
+ */
+case class NotWhen(path: String, disallowedValues: Any) extends Metadata {
+  override def appendMetadataToJsonSchema(obj: JsonAST.JObject): JsonAST.JObject = appendToDescription(obj, s"(Not when $path = ${disallowedValues match {
+    case listValues: List[Any] => listValues.mkString(",")
+    case value: Any => value.toString()
+    case None => None
+  }})")
+  def serializableForm = SerializableNotWhen(path, disallowedValues match {
+    case a: Any => ValueConversion.anyToJValueWithLists(a)
+  })
+}
+
+object NotWhenMatcher {
+  def matchValues(valueAtExpectedPosition: JValue, values: JValue) = (valueAtExpectedPosition, values) match {
+    case (_, JArray(list)) => !list.filter(anyValue => JsonCompare.equals(valueAtExpectedPosition, anyValue)).isEmpty
+    case (JNothing, JNull) => true
+    case (_, JNull) => JsonCompare.equals(valueAtExpectedPosition, JNull)
+    case (_, jVal: JValue) => JsonCompare.equals(valueAtExpectedPosition, jVal)
+  }
+}
+
+case class SerializableNotWhen(path: String, values: JValue)

--- a/src/main/scala/fi/oph/scalaschema/annotation/OnlyWhen.scala
+++ b/src/main/scala/fi/oph/scalaschema/annotation/OnlyWhen.scala
@@ -1,24 +1,11 @@
 package fi.oph.scalaschema.annotation
 
-import fi.oph.scalaschema.{Metadata, Serializer}
+import fi.oph.scalaschema.{Metadata, ValueConversion}
 import org.json4s.{JValue, JsonAST}
-import org.json4s.JsonAST.{JNull, JString}
 
 case class OnlyWhen(path: String, value: Any) extends Metadata {
   override def appendMetadataToJsonSchema(obj: JsonAST.JObject): JsonAST.JObject = appendToDescription(obj, s"(Only when $path = $value)")
-  def serializableForm = SerializableOnlyWhen(path, AnyToJson.anyToJValue(value))
+  def serializableForm = SerializableOnlyWhen(path, ValueConversion.anyToJValue(value))
 }
 
 case class SerializableOnlyWhen(path: String, value: JValue)
-
-private object AnyToJson {
-  // Use sparingly! Only supports numbers, strings, booleans and Option
-  def anyToJValue(x: Any): JValue = x match {
-    case None => JNull
-    case Some(x) => anyToJValue(x)
-    case s: String => JString(s)
-    case n: Number => Serializer.serializeNumber(n)
-    case b: Boolean => Serializer.serializeBoolean(b)
-    case _ => throw new IllegalArgumentException("Type not supported here: " + x.getClass)
-  }
-}

--- a/src/main/scala/fi/oph/scalaschema/extraction/AnyOfExtractor.scala
+++ b/src/main/scala/fi/oph/scalaschema/extraction/AnyOfExtractor.scala
@@ -2,7 +2,7 @@ package fi.oph.scalaschema.extraction
 
 import fi.oph.scalaschema.annotation._
 import fi.oph.scalaschema.{Schema, _}
-import org.json4s.JsonAST.JObject
+import org.json4s.JsonAST.{JObject}
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 
@@ -56,6 +56,12 @@ object AnyOfExtractor {
           List(OnlyWhenCriteria(keyPath, onlyWhens.map(_.serializableForm)))
       }
 
+      val notWhens: List[DiscriminatorCriterion] = s.metadata.collect({ case o:NotWhen => o}) match {
+        case Nil => Nil
+        case notWhens =>
+          List(NotWhenCriteria(keyPath, notWhens.map(_.serializableForm)))
+      }
+
       val criteria = discriminatorProps match {
         case Nil =>
           NoOtherPropertiesThan(keyPath, s.properties.map(_.key)) :: (s.properties.flatMap(propertyMatchers(contextPath, keyPath, _)))
@@ -63,7 +69,7 @@ object AnyOfExtractor {
           props.flatMap(propertyMatchers(contextPath, keyPath, _))
       }
 
-      AllOfCriterion(criteria ++ onlyWhens)
+      AllOfCriterion(criteria ++ onlyWhens ++ notWhens)
     case s: FlattenedSchema => AllOfCriterion(List(Flattened(keyPath, s, discriminatorCriteria(contextPath, s.property.schema, keyPath))))
     case s: NumberSchema => IsNumeric(keyPath, s)
     case s: StringSchema => IsString(keyPath, s)
@@ -228,12 +234,35 @@ object AnyOfExtractor {
     }
   }
 
+  case class NotWhenCriteria(keyPath: KeyPath, criteria: List[SerializableNotWhen]) extends DiscriminatorCriterion {
+    def weight = 9000
+
+    def apply(json: JsonCursor)(implicit context: ExtractionContext): List[String] = {
+      val valueAtKeyPath = keyPath(json)
+      val found = criteria.find { case SerializableNotWhen(path, values) =>
+        NotWhenMatcher.matchValues(valueAtKeyPath.navigate(path).json, values)
+      }
+      found match {
+        case Some(matching) => List(description)
+        case None => Nil
+      }
+    }
+
+    override def description: String = {
+      def convertToString(arr: JValue) = arr match {
+        case JArray(list) => list.map(someValue => JsonMethods.compact(someValue)).mkString(s",")
+        case value: JValue => JsonMethods.compact(value)
+      }
+        s"Not allowed, when ${criteria.map { case SerializableNotWhen(path, values) => s"${path} = [${convertToString(values)}]" }.mkString(" or ")}"
+    }
+  }
+
   case class NoOtherPropertiesThan(keyPath: KeyPath, keys: List[String]) extends DiscriminatorCriterion {
     def apply(value: JsonCursor)(implicit context: ExtractionContext): List[String] = PropertyExists(keyPath)(value) match {
       case Nil =>
         keyPath(value).json match {
           case JObject(values) =>
-            values.toList.map(_._1).filterNot(keys.contains(_)) match {
+            values.map(_._1).filterNot(keys.contains(_)) match {
               case Nil => Nil
               case unexpected => List(withKeyPath(s"allowed properties [${keys.mkString(", ")}] do not contain [${unexpected.mkString(", ")}]"))
             }

--- a/src/main/scala/fi/oph/scalaschema/extraction/ValidationError.scala
+++ b/src/main/scala/fi/oph/scalaschema/extraction/ValidationError.scala
@@ -1,6 +1,6 @@
 package fi.oph.scalaschema.extraction
 
-import fi.oph.scalaschema.annotation.{EnumValue, SerializableOnlyWhen}
+import fi.oph.scalaschema.annotation.{EnumValue, SerializableNotWhen, SerializableOnlyWhen}
 import org.json4s.JValue
 
 case class ValidationError(path: String, value: JValue, error: ValidationRuleViolation)
@@ -22,3 +22,4 @@ case class LessThanMinimumNumberOfItems(minimumItems: Int, @EnumValue("lessThanM
 case class MoreThanMaximumNumberOfItems(maximumItems: Int, @EnumValue("moreThanMaximumNumberOfItems") errorType: String = "moreThanMaximumNumberOfItems") extends ValidationRuleViolation
 case class OtherViolation(message: String, @EnumValue("otherViolation") errorType: String = "otherViolation") extends ValidationRuleViolation
 case class OnlyWhenMismatch(oneOfMustMatch: List[SerializableOnlyWhen], @EnumValue("onlyWhenMismatch") errorType: String="onlyWhenMismatch") extends ValidationRuleViolation
+case class NotWhenMismatch(noneMustMatch: List[SerializableNotWhen], @EnumValue("notWhenMismatch") errorType: String="notWhenMismatch") extends ValidationRuleViolation

--- a/src/test/scala/fi/oph/scalaschema/ValueConversionTest.scala
+++ b/src/test/scala/fi/oph/scalaschema/ValueConversionTest.scala
@@ -1,0 +1,69 @@
+package fi.oph.scalaschema
+
+import org.json4s.{JArray, JBool, JDouble, JInt, JNull, JString}
+import org.scalatest.Inside.inside
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+case class Something(val1: String)
+
+class ValueConversionTest extends AnyFreeSpec with Matchers {
+  "Value conversion" - {
+    "Converts Option correctly" in {
+      ValueConversion.anyToJValue(None) should matchPattern {
+        case JNull =>
+      }
+      ValueConversion.anyToJValue(Some("Hello")) should matchPattern {
+        case JString("Hello") =>
+      }
+    }
+    "Converts String correctly" in {
+      ValueConversion.anyToJValue("Hello") should matchPattern {
+        case JString("Hello") =>
+      }
+    }
+    "Converts Number correctly" in {
+      val integerExample = ValueConversion.anyToJValue(42)
+      val doubleExample = ValueConversion.anyToJValue(42.55)
+      inside(integerExample) {
+        case JInt(a) => {
+          a.toInt should be (42)
+        }
+      }
+      inside(doubleExample) {
+        case JDouble(a) => {
+          a should be (42.55)
+        }
+      }
+    }
+    "Converts Boolean correctly" in {
+      val booleanExample1 = ValueConversion.anyToJValue(true)
+      booleanExample1 should matchPattern {
+        case JBool(true) =>
+      }
+      val booleanExample2 = ValueConversion.anyToJValue(false)
+      booleanExample2 should matchPattern {
+        case JBool(false) =>
+      }
+    }
+    "Converts List correctly" in {
+      val listExample1 = ValueConversion.anyToJValueWithLists(List(true, false, 22, "Hello"))
+      listExample1 should matchPattern {
+        case JArray(List(JBool(true), JBool(false), _, JString("Hello"))) =>
+      }
+      val listExample2 = ValueConversion.anyToJValueWithLists(List("Hello", "World", "123"))
+      listExample2 should matchPattern {
+        case JArray(List(JString("Hello"), JString("World"), JString("123"))) =>
+      }
+      val listExample3 = ValueConversion.anyToJValueWithLists(List("Hello", List("World", 456), "123"))
+      listExample3 should matchPattern {
+        case JArray(List(JString("Hello"), JArray(List(JString("World"), _)), JString("123"))) =>
+      }
+    }
+    "Throws IllegalArgumentException on unknown type" in {
+      assertThrows[IllegalArgumentException] {
+        ValueConversion.anyToJValue(Something("ShouldThrow"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
The NotWhen annotation can be used to make a match, if any of the values in the annotation are found. E.g. ```NotWhen("something", List(1,2,3)``` will not match of the value of `something` if its value is `1`, `2` or `3`.

- [x] Implement `NotWhen`-annotation
- [x] Updated documentation in `README.md`
- [x]  Created ScalaDoc documentation for the annotation
- [x] Created tests for the `NotWhen`-annotation