### PR TITLE
Support outputting Scala class name to JSON object when serializing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,38 @@ object CustomSerializationExample extends App {
 }
 ```
 
+#### Including class reference in the serialized JSON
+
+You can emit the Scala class name to the serialized JSON by setting `includeClassReferences = true` in the `SerializationContext`:
+
+```scala
+case class Zoo(animals: List[Animal])
+case class Animal(name: String, age: Int)
+
+object SerializationExample extends App {
+  val context = SerializationContext(SchemaFactory.default, includeClassReferences = true)
+  val zoo = Zoo(List(Animal("giraffe", 23)))
+  val serialized: JValue = Serializer.serialize(zoo, context)
+  val stringValue: String = JsonMethods.pretty(serialized)
+  println(stringValue)
+  /*
+  
+  Output:
+  
+  {
+      "animals": [
+          {
+              "name":"giraffe",
+              "age":23,
+              "$class":"fi.oph.scalaschema.Animal"
+          }
+      ],
+      "$class":"fi.oph.scalaschema.Zoo"
+  }
+   */
+}
+```
+
 In the above example, all fields with the name "age" are hidden. More examples in this [test](https://github.com/Opetushallitus/scala-schema/blob/scala-2.12/src/test/scala/fi/oph/scalaschema/SerializationSpec.scala).
 
 ### Schemas and Factories

--- a/src/main/scala/fi/oph/scalaschema/ExtractionContext.scala
+++ b/src/main/scala/fi/oph/scalaschema/ExtractionContext.scala
@@ -16,7 +16,8 @@ case class ExtractionContext(schemaFactory: SchemaFactory,
                              ignoreUnexpectedProperties: Boolean = false,
                              allowEmptyStrings: Boolean = true,
                              criteriaCache: collection.mutable.Map[String, DiscriminatorCriterion] = collection.mutable.Map.empty,
-                             ignoreNonValidatingListItems: Boolean = false) {
+                             ignoreNonValidatingListItems: Boolean = false,
+                             stripClassReferences: Boolean = true) {
   def hasSerializerFor(schema: SchemaWithClassName) = customSerializerFor(schema).isDefined
   def customSerializerFor(schema: SchemaWithClassName) = customDeserializers.find(_.isApplicable(schema))
   def ifValidating(errors: => List[ValidationError]) = if (validate) { errors } else { Nil }

--- a/src/main/scala/fi/oph/scalaschema/Serializer.scala
+++ b/src/main/scala/fi/oph/scalaschema/Serializer.scala
@@ -3,12 +3,11 @@ package fi.oph.scalaschema
 import java.time.format.DateTimeFormatter.ISO_INSTANT
 import java.time.{LocalDate, LocalDateTime, ZoneId, ZonedDateTime}
 import java.util.Date
-
 import fi.oph.scalaschema.SchemaPropertyProcessor.SchemaPropertyProcessor
 import fi.oph.scalaschema.extraction.SchemaNotFoundException
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
-import org.json4s.JsonAST._
+import org.json4s.JsonAST.{JField, _}
 import org.json4s.{DefaultFormats, Extraction, Formats, JValue}
 
 import scala.reflect.runtime.{universe => ru}
@@ -80,7 +79,7 @@ object Serializer {
         case jValue => Some(JField(p.key, jValue))
       }
     }
-  })
+  } ++ (if(context.includeClassReferences) { List(JField("$class", JString(s.fullClassName))) } else { Nil }))
 
   def serializeString(x: Any): JValue = x match {
     case x: String => JString(x)
@@ -112,7 +111,7 @@ object Serializer {
   }
 }
 
-case class SerializationContext(schemaFactory: SchemaFactory, propertyProcessor: SchemaPropertyProcessor = (s, p) => List(p), omitEmptyFields: Boolean = true)
+case class SerializationContext(schemaFactory: SchemaFactory, propertyProcessor: SchemaPropertyProcessor = (s, p) => List(p), omitEmptyFields: Boolean = true, includeClassReferences: Boolean = false)
 
 object SchemaPropertyProcessor {
   type SchemaPropertyProcessor = (ClassSchema, Property) => List[Property]

--- a/src/test/scala/fi/oph/scalaschema/ClassReferenceTest.scala
+++ b/src/test/scala/fi/oph/scalaschema/ClassReferenceTest.scala
@@ -1,0 +1,57 @@
+package fi.oph.scalaschema
+
+import fi.oph.scalaschema.extraction.{UnexpectedProperty, ValidationError}
+import org.json4s.JString
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.reflect.runtime.{universe => ru}
+
+case class NameClass(value: Int)
+case class ClassRefTestClass(name: NameClass, stuff: List[NameClass])
+
+case class Nested3(value: Int)
+case class Nested2(value: Nested3)
+case class Nested1(value: Nested2)
+case class MultiLevelRefTestClass(name: Nested1)
+
+class ClassReferenceTest extends AnyFreeSpec with Matchers {
+  "Serialization" - {
+    "Should include class references, when includeClassReferences parameter is set to 'true'" in {
+      val zoo = Zoo(List(Animal("giraffe", 23)))
+      testSerialization(zoo, """{"animals":[{"name":"giraffe","age":23,"$class":"fi.oph.scalaschema.Animal"}],"$class":"fi.oph.scalaschema.Zoo"}""", context = SerializationContext(SchemaFactory.default, includeClassReferences = true))
+    }
+    "Should include class references, when includeClassReferences parameter is set to 'true', for nested classes" in {
+      val zoo = MultiLevelRefTestClass(Nested1(Nested2(Nested3(42))))
+      testSerialization(zoo, """{"name":{"value":{"value":{"value":42,"$class":"fi.oph.scalaschema.Nested3"},"$class":"fi.oph.scalaschema.Nested2"},"$class":"fi.oph.scalaschema.Nested1"},"$class":"fi.oph.scalaschema.MultiLevelRefTestClass"}""", context = SerializationContext(SchemaFactory.default, includeClassReferences = true))
+    }
+    "Should not include class references, when includeClassReferences parameter is set to 'false'" in {
+      val zoo = Zoo(List(Animal("giraffe", 23)))
+      testSerialization(zoo, """{"animals":[{"name":"giraffe","age":23}]}""", context = SerializationContext(SchemaFactory.default))
+    }
+    "Should not include class references, when includeClassReferences parameter is omitted" in {
+      val zoo = Zoo(List(Animal("giraffe", 23)))
+      testSerialization(zoo, """{"animals":[{"name":"giraffe","age":23}]}""", context = SerializationContext(SchemaFactory.default, includeClassReferences = false))
+    }
+  }
+  "Deserialization" - {
+    "Should not include class references, when extracting JSON object into Scala class" in {
+      implicit val context = ExtractionContext(SchemaFactory.default)
+      SchemaValidatingExtractor.extract[Zoo]("""{"animals":[{"name":"giraffe","age":23,"$class":"fi.oph.scalaschema.Animal"}],"$class":"fi.oph.scalaschema.Zoo"}""") should equal(Right(Zoo(List(Animal("giraffe", 23)))))
+    }
+    "Should fail if trying to include class references" in {
+      implicit val context = ExtractionContext(SchemaFactory.default, stripClassReferences = false)
+      SchemaValidatingExtractor.extract[Zoo]("""{"animals":[{"name":"giraffe","age":23,"$class":"fi.oph.scalaschema.Animal"}],"$class":"fi.oph.scalaschema.Zoo"}""") should equal(Left(List(
+        ValidationError("animals.0.$class", JString("fi.oph.scalaschema.Animal"), UnexpectedProperty()),
+        ValidationError("$class", JString("fi.oph.scalaschema.Zoo"), UnexpectedProperty())
+      )))
+    }
+  }
+
+  private def testSerialization[T](x: T, expected: String, context: SerializationContext = defaultContext)(implicit tag: ru.TypeTag[T]) = {
+    val jValue = Serializer.serialize(x, context)
+    org.json4s.jackson.JsonMethods.compact(jValue) should equal(expected)
+  }
+
+  private def defaultContext[T] = SerializationContext(SchemaFactory.default)
+}


### PR DESCRIPTION
This PR adds support for including Scala class name in the outputted JSON when serializing the object. By default, the `$class` field is removed from the input JSON when deserializing to prevent deserialization errors, as the `$class` field does not actually exist in the schema.

Example:

```scala
case class Zoo(animals: List[Animal])
case class Animal(name: String, age: Int)

object SerializationExample extends App {
  val context = SerializationContext(SchemaFactory.default, includeClassReferences = true)
  val zoo = Zoo(List(Animal("giraffe", 23)))
  val serialized: JValue = Serializer.serialize(zoo, context)
  val stringValue: String = JsonMethods.pretty(serialized)
  println(stringValue)
  /*
  
  Output:
  
  {
      "animals": [
          {
              "name":"giraffe",
              "age":23,
              "$class":"fi.oph.scalaschema.Animal"
          }
      ],
      "$class":"fi.oph.scalaschema.Zoo"
  }
   */
}
```