### PR TITLE
Emit structural annotations as JSON Schema fields

### DIFF
--- a/src/main/scala/fi/oph/scalaschema/Metadata.scala
+++ b/src/main/scala/fi/oph/scalaschema/Metadata.scala
@@ -2,7 +2,7 @@ package fi.oph.scalaschema
 
 import fi.oph.scalaschema.annotation.EnumValue
 import org.json4s.JsonAST
-import org.json4s.JsonAST.{JNothing, JObject, JString}
+import org.json4s.JsonAST.{JArray, JNothing, JObject, JString}
 
 import scala.annotation.StaticAnnotation
 
@@ -34,6 +34,15 @@ trait JsonMetadataSupport {
 
   def addEnumValue(value: Any, p: Property): Property = {
     p.copy(schema = EnumValue.addEnumValues(p.schema, List(value)))
+  }
+
+  // Appends a string to a JSON array field, accumulating across multiple annotations.
+  def appendToStringArray(obj: JObject, key: String, value: String): JObject = {
+    val existing = obj.\(key) match {
+      case JArray(a) => a
+      case _ => Nil
+    }
+    JObject(obj.obj.filterNot(_._1 == key) :+ (key -> JArray(existing :+ JString(value))))
   }
 }
 

--- a/src/main/scala/fi/oph/scalaschema/SchemaToJson.scala
+++ b/src/main/scala/fi/oph/scalaschema/SchemaToJson.scala
@@ -82,7 +82,9 @@ object SchemaToJson {
 
   private def toJsonProperties(properties: List[Property]): JValue = {
     JObject(properties.map { property =>
-        (property.key, appendMetadata(appendMetadata(toJsonSchemaWithoutMetadata(property.schema), property.metadata), property.schema.metadata))
+        val json = appendMetadata(appendMetadata(toJsonSchemaWithoutMetadata(property.schema), property.metadata), property.schema.metadata)
+        val withSynthetic = if (property.synthetic || property.computed) json.merge(JObject("synthetic" -> JBool(true))) else json
+        (property.key, withSynthetic)
     })
   }
 

--- a/src/main/scala/fi/oph/scalaschema/annotation/DefaultValue.scala
+++ b/src/main/scala/fi/oph/scalaschema/annotation/DefaultValue.scala
@@ -1,7 +1,7 @@
 package fi.oph.scalaschema.annotation
 
 import fi.oph.scalaschema.Metadata
-import org.json4s.JsonAST.JObject
+import org.json4s.JsonAST.{JObject, JString}
 
 case class DefaultValue(value: Any) extends Metadata {
   override def appendMetadataToJsonSchema(obj: JObject) = {
@@ -9,7 +9,7 @@ case class DefaultValue(value: Any) extends Metadata {
       case v: Option[_] => v.map(_.toString).getOrElse("null")
       case v: Any => v
     }
-    appendToDescription(obj, s"(default value: ${display})")
+    appendToDescription(obj.merge(JObject("default" -> JString(display.toString))), s"(default value: ${display})")
   }
 }
 

--- a/src/main/scala/fi/oph/scalaschema/annotation/DeserializeSingleValueAsArray.scala
+++ b/src/main/scala/fi/oph/scalaschema/annotation/DeserializeSingleValueAsArray.scala
@@ -1,12 +1,12 @@
 package fi.oph.scalaschema.annotation
 
 import fi.oph.scalaschema.Metadata
-import org.json4s.JsonAST.JObject
+import org.json4s.JsonAST.{JBool, JObject}
 
 /**
  * Used to mark a list field to accept also a single value.
  */
 class DeserializeSingleValueAsArray extends Metadata {
   override def appendMetadataToJsonSchema(obj: JObject) =
-    appendToDescription(obj, s"(when deserializing also accepts a single value)")
+    appendToDescription(obj.merge(JObject("acceptsSingleValue" -> JBool(true))), s"(when deserializing also accepts a single value)")
 }

--- a/src/main/scala/fi/oph/scalaschema/annotation/NotWhen.scala
+++ b/src/main/scala/fi/oph/scalaschema/annotation/NotWhen.scala
@@ -19,11 +19,14 @@ import org.json4s.{JArray, JNothing, JNull, JValue, JsonAST}
  * @param disallowedValues Disallowed values. Can be a [[scala.AnyValCompanion]], [[scala.None]] or a [[scala.collection.immutable.List]] of [[scala.AnyValCompanion]].
  */
 case class NotWhen(path: String, disallowedValues: Any) extends Metadata {
-  override def appendMetadataToJsonSchema(obj: JsonAST.JObject): JsonAST.JObject = appendToDescription(obj, s"(Not when $path = ${disallowedValues match {
-    case listValues: List[Any] => listValues.mkString(",")
-    case value: Any => value.toString()
-    case None => None
-  }})")
+  override def appendMetadataToJsonSchema(obj: JsonAST.JObject): JsonAST.JObject = {
+    val condition = s"Not when $path = ${disallowedValues match {
+      case listValues: List[Any] => listValues.mkString(",")
+      case value: Any => value.toString()
+      case None => None
+    }}"
+    appendToDescription(appendToStringArray(obj, "conditions", condition), s"($condition)")
+  }
   def serializableForm = SerializableNotWhen(path, disallowedValues match {
     case a: Any => ValueConversion.anyToJValueWithLists(a)
   })

--- a/src/main/scala/fi/oph/scalaschema/annotation/OnlyWhen.scala
+++ b/src/main/scala/fi/oph/scalaschema/annotation/OnlyWhen.scala
@@ -4,7 +4,10 @@ import fi.oph.scalaschema.{Metadata, ValueConversion}
 import org.json4s.{JValue, JsonAST}
 
 case class OnlyWhen(path: String, value: Any) extends Metadata {
-  override def appendMetadataToJsonSchema(obj: JsonAST.JObject): JsonAST.JObject = appendToDescription(obj, s"(Only when $path = $value)")
+  override def appendMetadataToJsonSchema(obj: JsonAST.JObject): JsonAST.JObject = {
+    val condition = s"Only when $path = $value"
+    appendToDescription(appendToStringArray(obj, "conditions", condition), s"($condition)")
+  }
   def serializableForm = SerializableOnlyWhen(path, ValueConversion.anyToJValue(value))
 }
 

--- a/src/test/scala/fi/oph/scalaschema/JsonSchemaTest.scala
+++ b/src/test/scala/fi/oph/scalaschema/JsonSchemaTest.scala
@@ -71,7 +71,7 @@ class JsonSchemaTest extends AnyFreeSpec with Matchers {
         jsonSchemaPropertiesOf(classOf[Arrays]) should equal("""{"things":{"type":"array","items":{"type":"number"}}}""")
       }
       "List accepting single value as array" in {
-        jsonSchemaPropertiesOf(classOf[ListsWithSingleValueAsArray]) should equal("""{"things":{"type":"array","items":{"type":"number"},"description":"(when deserializing also accepts a single value)"}}""")
+        jsonSchemaPropertiesOf(classOf[ListsWithSingleValueAsArray]) should equal("""{"things":{"type":"array","items":{"type":"number"},"acceptsSingleValue":true,"description":"(when deserializing also accepts a single value)"}}""")
       }
     }
     "Maps" in {
@@ -108,7 +108,7 @@ class JsonSchemaTest extends AnyFreeSpec with Matchers {
     "Annotations" - {
       "@DefaultValue" - {
         "Fields with @DefaultValue are treated as non-required" in {
-          jsonSchemaOf(classOf[BooleansWithDefault]) should equal("""{"type":"object","properties":{"field":{"type":"boolean","description":"(default value: true)"}},"id":"#booleanswithdefault","additionalProperties":false,"title":"Booleans with default"}""")
+          jsonSchemaOf(classOf[BooleansWithDefault]) should equal("""{"type":"object","properties":{"field":{"type":"boolean","default":"true","description":"(default value: true)"}},"id":"#booleanswithdefault","additionalProperties":false,"title":"Booleans with default"}""")
         }
       }
       "@Description" - {
@@ -151,13 +151,13 @@ class JsonSchemaTest extends AnyFreeSpec with Matchers {
       }
       "@SyntheticProperty" - {
         "for method in case class" in {
-          jsonSchemaOf(classOf[WithSyntheticProperties]) should equal("""{"type":"object","properties":{"field1":{"type":"boolean"},"field2":{"type":"array","items":{"type":"boolean"}}},"id":"#withsyntheticproperties","additionalProperties":false,"title":"With synthetic properties"}""")
+          jsonSchemaOf(classOf[WithSyntheticProperties]) should equal("""{"type":"object","properties":{"field1":{"type":"boolean","synthetic":true},"field2":{"type":"array","items":{"type":"boolean"},"synthetic":true}},"id":"#withsyntheticproperties","additionalProperties":false,"title":"With synthetic properties"}""")
         }
         "for method in trait" in {
-          jsonSchemaOf(classOf[WithTraitWithSyntheticProperties]) should equal("""{"type":"object","properties":{"field":{"type":"boolean","description":"synthetic field"}},"id":"#withtraitwithsyntheticproperties","additionalProperties":false,"title":"With trait with synthetic properties"}""")
+          jsonSchemaOf(classOf[WithTraitWithSyntheticProperties]) should equal("""{"type":"object","properties":{"field":{"type":"boolean","description":"synthetic field","synthetic":true}},"id":"#withtraitwithsyntheticproperties","additionalProperties":false,"title":"With trait with synthetic properties"}""")
         }
         "for complex hierarchy of traits" in {
-          jsonSchemaOf(classOf[WithComplexHierarchyOfTraitsWithSyntheticProperties]) should equal("""{"type":"object","properties":{"field":{"type":"boolean","description":"synthetic field"}},"id":"#withcomplexhierarchyoftraitswithsyntheticproperties","additionalProperties":false,"title":"With complex hierarchy of traits with synthetic properties"}""")
+          jsonSchemaOf(classOf[WithComplexHierarchyOfTraitsWithSyntheticProperties]) should equal("""{"type":"object","properties":{"field":{"type":"boolean","description":"synthetic field","synthetic":true}},"id":"#withcomplexhierarchyoftraitswithsyntheticproperties","additionalProperties":false,"title":"With complex hierarchy of traits with synthetic properties"}""")
         }
         "for method in trait overridden by val" in {
           jsonSchemaOf(classOf[WithOverriddenSyntheticProperties]) should equal("""{"type":"object","properties":{"field":{"type":"boolean","description":"synthetic field"}},"id":"#withoverriddensyntheticproperties","additionalProperties":false,"title":"With overridden synthetic properties","required":["field"]}""")


### PR DESCRIPTION
Some annotations only append to the JSON Schema `description` string, so downstream tools can't render them structurally. This adds additive structured fields (description text unchanged, keys ignored by JSON Schema validators):

- `DefaultValue` → `default`
- `NotWhen` / `OnlyWhen` → `conditions` (accumulating array; new `appendToStringArray` helper in `Metadata`)
- `DeserializeSingleValueAsArray` → `acceptsSingleValue`
- `@SyntheticProperty` / `@ComputedProperty` → `synthetic` (in `SchemaToJson.toJsonProperties`)

Motivated by the Koski JSON Schema Viewer (TOR-2464), which shows these as their own rows instead of parsing the description. Snapshot tests updated; `mvn test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)